### PR TITLE
Performance!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>com.github.TechFortress</groupId>
 			<artifactId>GriefPrevention</artifactId>
-			<version>16.11.6</version>
+			<version>16.17.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.kyori</groupId>

--- a/src/main/java/no/vestlandetmc/BanFromClaim/listener/GDListener.java
+++ b/src/main/java/no/vestlandetmc/BanFromClaim/listener/GDListener.java
@@ -7,7 +7,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import com.flowpowered.math.vector.Vector3i;
 import com.griefdefender.api.Core;
@@ -21,11 +20,12 @@ import no.vestlandetmc.BanFromClaim.handler.MessageHandler;
 
 public class GDListener implements Listener {
 
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onPlayerEnterClaim(PlayerMoveEvent e) {
-		final Player player = e.getPlayer();
-		final Location locTo = e.getTo();
 		final Location locFrom = e.getFrom();
+		final Location locTo = e.getTo();
+		if(locFrom.getBlock().equals(locTo.getBlock())) { return; }
+		final Player player = e.getPlayer();
 		final Core gd = GriefDefender.getCore();
 		final Vector3i vectorTo = Vector3i.from(locTo.getBlockX(), locTo.getBlockY(), locTo.getBlockZ());
 		final Vector3i vectorFrom = Vector3i.from(locFrom.getBlockX(), locFrom.getBlockY(), locFrom.getBlockZ());
@@ -53,13 +53,9 @@ public class GDListener implements Listener {
 						MessageHandler.sendTitle(player, Messages.TITLE_MESSAGE, Messages.SUBTITLE_MESSAGE);
 						MessageHandler.spamMessageClaim.add(player.getUniqueId().toString());
 
-						new BukkitRunnable() {
-							@Override
-							public void run() {
-								MessageHandler.spamMessageClaim.remove(player.getUniqueId().toString());
-							}
-
-						}.runTaskLater(BfcPlugin.getInstance(), 5 * 20L);
+						Bukkit.getScheduler().runTaskLater(BfcPlugin.getInstance(), () -> {
+							MessageHandler.spamMessageClaim.remove(player.getUniqueId().toString());
+						}, 5L * 20L);
 					}
 				}
 			}

--- a/src/main/java/no/vestlandetmc/BanFromClaim/listener/GPListener.java
+++ b/src/main/java/no/vestlandetmc/BanFromClaim/listener/GPListener.java
@@ -1,11 +1,11 @@
 package no.vestlandetmc.BanFromClaim.listener;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import me.ryanhamshire.GriefPrevention.Claim;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
@@ -16,11 +16,13 @@ import no.vestlandetmc.BanFromClaim.handler.MessageHandler;
 
 public class GPListener implements Listener {
 
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onPlayerEnterClaim(PlayerMoveEvent e) {
+		final Location locFrom = e.getFrom();
+		final Location locTo = e.getTo();
+		if(locFrom.getBlock().equals(locTo.getBlock())) { return; }
 		final Player player = e.getPlayer();
-		final Location loc = e.getTo();
-		final Claim claim = GriefPrevention.instance.dataStore.getClaimAt(loc, true, null);
+		final Claim claim = GriefPrevention.instance.dataStore.getClaimAt(locTo, true, null);
 
 		if(player.hasPermission("bfc.bypass")) { return; }
 
@@ -33,14 +35,9 @@ public class GPListener implements Listener {
 					MessageHandler.sendTitle(player, Messages.TITLE_MESSAGE, Messages.SUBTITLE_MESSAGE);
 					MessageHandler.spamMessageClaim.add(player.getUniqueId().toString());
 
-
-					new BukkitRunnable() {
-						@Override
-						public void run() {
-							MessageHandler.spamMessageClaim.remove(player.getUniqueId().toString());
-						}
-
-					}.runTaskLater(BfcPlugin.getInstance(), 5 * 20L);
+					Bukkit.getScheduler().runTaskLater(BfcPlugin.getInstance(), () -> {
+						MessageHandler.spamMessageClaim.remove(player.getUniqueId().toString());
+					}, 5L * 20L);
 				}
 			}
 		}

--- a/src/main/java/no/vestlandetmc/BanFromClaim/listener/PlayerListener.java
+++ b/src/main/java/no/vestlandetmc/BanFromClaim/listener/PlayerListener.java
@@ -11,7 +11,7 @@ import no.vestlandetmc.BanFromClaim.handler.UpdateNotification;
 
 public class PlayerListener implements Listener {
 
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void playerJoin(PlayerJoinEvent p) {
 		final Player player = p.getPlayer();
 


### PR DESCRIPTION
- Only check if the player is in a claim when you move into a new block,
it's pointless checking every single move event when in the same block
and its impossible to enter a claim unless they move to another
block just hurts performance.
- Don't make a new thread for removing the player from the
spamMessageClaim map, eating up the internal thread pool.
- Add ignoreCancelled to the events, no point in running if another
the plugin is cancelling the event.
- Update GP to the latest version (At this time)