### PR TITLE
Don't teleport riding player if they're trusted or can bypass

### DIFF
--- a/src/main/java/no/vestlandetmc/BanFromClaim/listener/RegionListener.java
+++ b/src/main/java/no/vestlandetmc/BanFromClaim/listener/RegionListener.java
@@ -42,16 +42,15 @@ public class RegionListener implements Listener {
 			final Player target = PlayerRidePlayer.getPassenger(player);
 			boolean hasAttacked = false;
 
-			if (target != null && (claimData.isAllBanned(regionID) || playerBanned(target, regionID) || playerBanned(player, regionID))) {
+			if (target != null && !region.hasTrust(target, regionID) && !canBypass(target)
+					&& (claimData.isAllBanned(regionID) || playerBanned(target, regionID) || playerBanned(player, regionID))) {
 				target.teleport(player.getLocation().add(0, 4, 0));
 			}
 
 			if (CombatMode.attackerContains(player.getUniqueId()))
 				hasAttacked = CombatMode.getAttacker(player.getUniqueId()).equals(ownerUUID);
 
-			if (player.hasPermission("bfc.bypass") || player.getGameMode().equals(GameMode.SPECTATOR)) {
-				return;
-			}
+			if (canBypass(player)) return;
 
 			if ((claimData.isAllBanned(regionID) || playerBanned(player, regionID)) && !hasAttacked && !region.hasTrust(player, regionID)) {
 				final String regionIdFrom = region.getRegionID(locFrom);
@@ -112,6 +111,10 @@ public class RegionListener implements Listener {
 		}
 
 	}
+
+	private boolean canBypass(Player player) {
+        return player.hasPermission("bfc.bypass") || player.getGameMode().equals(GameMode.SPECTATOR);
+    }
 
 	private boolean playerBanned(Player player, String claimID) {
 		final ClaimData claimData = new ClaimData();


### PR DESCRIPTION
This PR fixes a bug where if a claim has /bfcall enabled (all players banned), a trusted/bypassing player jumping (or even standing) on top of another player gets teleported up when the other player moves around. This "behaviour" can be used to e.g. teleport through blocks, which shouldn't be possible. The logic also affected vanished players on our server, so this should fix that as well.

I wasn't exactly sure why the teleportation logic is there, but I'm assuming it has something to do with dismounting the riding player. This should still keep everything working as intended, as IMO a trusted player riding another player shouldn't get kicked off.